### PR TITLE
Corregir props

### DIFF
--- a/React/3-ReactState/ej5/src/Main.js
+++ b/React/3-ReactState/ej5/src/Main.js
@@ -41,13 +41,8 @@ function Main(props) {
    return <main>{props.libros.map((libro, index) => {
       
       return (<Tarjeta
-         titulo={libro.title}
-         imagen={libro.formats["image/jpeg"]}
-         autor={libro.authors.map((autor) => (autor.name))}
-         id={libro.id}
-         genero={libro.subjects[index]}
-         descargas={libro.download_count}
-         lenguages={libro.languages} />
+         key={libro.id}
+         {...libro} />
       )
    })}</main>
 }


### PR DESCRIPTION
El problema es que le estás pasando a las props de Tarjeta los datos transformados (titulo, autor, etc), pero en `Tarjeta` lo usas como si viniese sin transformar (authors, title, etc).

La solución puede ser usando la destructuración (?) de objetos, para pasarle las las propiedades de `libro` tal cual a las props.
Otra opción es usar en `Tarjeta` las props correctas (titulo)